### PR TITLE
fix 'edit this page' links

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -50,15 +50,20 @@ module.exports = {
             {
                 docs: {
                     sidebarPath: require.resolve('./sidebars.js'),
-                    // Please change this to your repo.
-                    editUrl:
-                        'https://github.com/k8ty-app/clatto-verata-zio/edit/main/',
+                    editUrl: function ({
+                                           locale,
+                                           version,
+                                           versionDocsDirPath,
+                                           docPath,
+                                           permalink,
+                                       }) {
+                        return `https://github.com/k8ty-app/clatto-verata-zio/edit/main/mdocs/${docPath}`;
+                    }
                 },
                 blog: {
                     showReadingTime: true,
-                    // Please change this to your repo.
                     editUrl:
-                        'https://github.com/k8ty-app/clatto-verata-zio/edit/main/blog/',
+                        'https://github.com/k8ty-app/clatto-verata-zio/edit/main/',
                 },
                 theme: {
                     customCss: require.resolve('./src/css/custom.css'),


### PR DESCRIPTION
Link back to blog was incorrect

1.  Remove extra `/blog` segment in edit blog url
2. Compute edit url for docs using `mdocs`, since `docs` are not tracked